### PR TITLE
Remove extra scene add

### DIFF
--- a/src/examples/physicsExample/scene.js
+++ b/src/examples/physicsExample/scene.js
@@ -32,9 +32,6 @@ scene.initGame = () => {
 
     // create controller models
     XRInput.CreateControllerModel(controller, scene);
-
-    // add to scene
-    scene.add(controller);
   });
 
   // BLOCK TOWER


### PR DESCRIPTION
`scene.add(controller)` is called inside `XRInput.CreateControllerModel` and also called after. Removing the extra call.

I haven't officially contributed, so thought this would be a good, easy place to start.