### PR TITLE
correct gltf paths, lit default scene

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5639,6 +5639,16 @@
         }
       }
     },
+    "gltf-webpack-loader": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/gltf-webpack-loader/-/gltf-webpack-loader-1.0.6.tgz",
+      "integrity": "sha512-0U5IqtRoXpkBF29uEokhTDvG8E82CzyOpHKyYoCL3Rf09sYxe8iyxYuDlSBmiuuLLIljCUt2ckSb3V3ARXqrUw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.2.3",
+        "schema-utils": "^1.0.0"
+      }
+    },
     "got": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10250,9 +10250,9 @@
       }
     },
     "three": {
-      "version": "0.117.1",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.117.1.tgz",
-      "integrity": "sha512-t4zeJhlNzUIj9+ub0l6nICVimSuRTZJOqvk3Rmlu+YGdTOJ49Wna8p7aumpkXJakJfITiybfpYE1XN1o1Z34UQ=="
+      "version": "0.118.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.118.1.tgz",
+      "integrity": "sha512-NYziIWAJg1ON5YJosT4eWCe/kmEOXC9pMJjqwsVtfIMrlP5qqassS0y99zs9INJUYtmxLsrNCdi9FzUWBKE6XQ=="
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "compression-webpack-plugin": "^4.0.0",
     "css-loader": "^3.5.3",
     "file-loader": "^6.0.0",
+    "gltf-webpack-loader": "^1.0.6",
     "html-loader": "^1.1.0",
     "html-webpack-plugin": "^4.3.0",
     "imagemin-jpegtran": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "firebase": "^7.14.5",
     "inquirer": "^7.2.0",
     "speak-tts": "^2.0.8",
-    "three": "^0.117.1"
+    "three": "^0.118.1"
   },
   "devDependencies": {
     "@babel/core": "^7.9.6",

--- a/src/engine/engine.js
+++ b/src/engine/engine.js
@@ -1,5 +1,5 @@
 // scene to run:
-import { scene } from "../examples/defaultScene";
+import { scene } from "../examples/defaultscene";
 
 import State from "./state";
 import { PerspectiveCamera, AudioListener } from "three";

--- a/src/examples/defaultscene.js
+++ b/src/examples/defaultscene.js
@@ -10,28 +10,26 @@ import {
 } from "three";
 const scene = new Scene();
 
-const rings = [
-  [new Vector3(1, 0, 1), new Color(0xff0000), 0.2],
-  [new Vector3(1, -1, 0), new Color(0x00ff00), 0.15],
-  [new Vector3(0, 1, 0), new Color(0x0000ff), 0.1],
+const ringsData = [
+  { axis: new Vector3(1, 0, 1), color: new Color(0xff0000), scale: 0.2 },
+  { axis: new Vector3(1, -1, 0), color: new Color(0x00ff00), scale: 0.15 },
+  { axis: new Vector3(0, 1, 0), color: new Color(0x0000ff), scale: 0.1 },
 ];
 
-rings.forEach((entry, i) => {
+ringsData.forEach((ringData, i) => {
   const ring = new Mesh(
     new TorusBufferGeometry(1, 0.065, 64, 64),
     new MeshStandardMaterial({
       metalness: 0.5,
       roughness: 0.5,
-      color: entry[1],
+      color: ringData.color,
     })
   );
   ring.position.z -= 1;
-  ring.scale.set(entry[2], entry[2], entry[2]);
+  ring.scale.set(ringData.scale, ringData.scale, ringData.scale);
 
-  const axis = new Vector3();
-  axis.copy(entry[0]);
   ring.Update = () => {
-    ring.rotateOnAxis(axis, 0.0033 * (i + 1));
+    ring.rotateOnAxis(ringData.axis, 0.0033 * (i + 1));
   };
   scene.add(ring);
 });

--- a/src/examples/defaultscene.js
+++ b/src/examples/defaultscene.js
@@ -3,8 +3,6 @@ import {
   Scene,
   TorusBufferGeometry,
   DirectionalLight,
-  AmbientLight,
-  HemisphereLight,
   Mesh,
   Vector3,
   MeshStandardMaterial,

--- a/src/examples/defaultscene.js
+++ b/src/examples/defaultscene.js
@@ -1,40 +1,45 @@
 // default scene loaded in src/engine/engine.js
-
 import {
   Scene,
   TorusBufferGeometry,
-  MeshNormalMaterial,
+  DirectionalLight,
+  AmbientLight,
+  HemisphereLight,
   Mesh,
   Vector3,
+  MeshStandardMaterial,
+  Color,
 } from "three";
 const scene = new Scene();
 
-scene.init = () => {
-  scene.traverse(e => {
-    scene.remove(e);
-  });
+const rings = [
+  [new Vector3(1, 0, 1), new Color(0xff0000), 0.2],
+  [new Vector3(1, -1, 0), new Color(0x00ff00), 0.15],
+  [new Vector3(0, 1, 0), new Color(0x0000ff), 0.1],
+];
 
-  const rots = [
-    new Vector3(-1, 0, 0),
-    new Vector3(1, 1, 0),
-    new Vector3(0, -1, 0),
-  ];
-  for (var i = 0; i < 3; i++) {
-    const placeholder = new Mesh(
-      new TorusBufferGeometry(1, 0.05, 16, 32),
-      new MeshNormalMaterial({ wireframe: true })
-    );
-    placeholder.position.z -= 5;
-    placeholder.scale.set(1 - i * 0.33, 1 - i * 0.33, 1 - i * 0.33);
-    const axis = new Vector3();
-    axis.copy(rots[i]);
-    placeholder.Update = () => {
-      placeholder.rotateOnAxis(axis, 0.007);
-    };
-    scene.add(placeholder);
-  }
-};
+rings.forEach((entry, i) => {
+  const ring = new Mesh(
+    new TorusBufferGeometry(1, 0.065, 64, 64),
+    new MeshStandardMaterial({
+      metalness: 0.5,
+      roughness: 0.5,
+      color: entry[1],
+    })
+  );
+  ring.position.z -= 1;
+  ring.scale.set(entry[2], entry[2], entry[2]);
 
-scene.init();
+  const axis = new Vector3();
+  axis.copy(entry[0]);
+  ring.Update = () => {
+    ring.rotateOnAxis(axis, 0.0033 * (i + 1));
+  };
+  scene.add(ring);
+});
+
+const light = new DirectionalLight(0xffffff, 3.5);
+light.position.set(0, 13, 3);
+scene.add(light);
 
 export { scene };

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -57,7 +57,15 @@ module.exports = {
         ],
       },
       {
-        test: /\.(gltf|glb|obj|mtl|fbx|dae|bin)$/,
+        test: /\.(gltf)$/,
+        use: [
+          {
+            loader: "gltf-webpack-loader",
+          },
+        ],
+      },
+      {
+        test: /\.(glb|obj|mtl|fbx|dae|bin)$/,
         use: [
           {
             loader: "file-loader",


### PR DESCRIPTION
On build, images and assets are still organized to folders as before but the model's .gltf is automatically rewritten to reference the correct texture file paths.

utilizes [gltf-webpack-loader](https://www.npmjs.com/package/gltf-webpack-loader). 
Resolves #10 and resolves #8.

To test, import any gltf file (text-format, `gltf`, _not_ `.glb`) into your scene, `npm run build` and observe it loading correctly. 
Remember you'll have to serve index.html if running locally to avoid CORS problems when loading textures. [http-server](https://www.npmjs.com/package/http-server) is a quick solution.