### PR TITLE
restore three version to 122

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11142,9 +11142,9 @@
       }
     },
     "three": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.128.0.tgz",
-      "integrity": "sha512-i0ap/E+OaSfzw7bD1TtYnPo3VEplkl70WX5fZqZnfZsE3k3aSFudqrrC9ldFZfYFkn1zwDmBcdGfiIm/hnbyZA=="
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.122.0.tgz",
+      "integrity": "sha512-bgYMo0WdaQhf7DhLE8OSNN/rVFO5J4K1A2VeeKqoV4MjjuHjfCP6xLpg8Xedhns7NlEnN3sZ6VJROq19Qyl6Sg=="
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "inquirer": "^7.2.0",
     "loader-utils": "^2.0.0",
     "speak-tts": "^2.0.8",
-    "three": "^0.128.0"
+    "three": "^0.122.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.6",


### PR DESCRIPTION
downgrade fix works, XRPK is now performant - good catch, @timgcarlson!
(what kills me is I swear I've seen this before and _forgot_. Will add notes on bug to add to MAIT)